### PR TITLE
プロフィール非公開時の投稿、投稿検索修正

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -45,6 +45,10 @@
   font-weight: bold;
 }
 
+.category-label {
+   white-space: nowrap;
+}
+
 .public_status {
   margin: 50px;
 }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -248,13 +248,12 @@ class PostsController < ApplicationController
     # @posts_tag = []
     # @post_tag_ids = []
     
+     #プロフィールが「非公開(2)」となっているユーザーの投稿または「非公開(2)」の投稿
+    unpublic_user_profiles = UserProfile.where(public_status_region: 2).or(UserProfile.where(public_status_business: 2))
+    @unpublic_posts = Post.where(user_id: unpublic_user_profiles.pluck(:user_id)) + Post.where(public_status_id: 2)
+    
     #「全ての投稿」が選択された場合
-    # if @post_type == "0"
-     @posts_post_type = Post.all
-    # #「地域側投稿」または「起業希望者投稿」が選択された場合 
-    # else  
-    # @posts_post_type = Post.where(post_type: @post_type)
-    # end
+    @posts_post_type = Post.all - @unpublic_posts
     @posts_post_type_ids = @posts_post_type.pluck(:id)
     
     #キーワードが入力された場合　
@@ -274,10 +273,12 @@ class PostsController < ApplicationController
     end 
     
    
-    @posts = @posts_post_type_keyword_prefecture.includes(:favorite_users)
+    @posts = @posts_post_type_keyword_prefecture
+    
+     #件数表示
+    @posts_count = @posts.count
     
     #ページネーション
-    @posts_count = @posts.count
     @posts = Kaminari.paginate_array(@posts).page(params[:page]).per(10)
     # #「投稿タイプ」と「キーワード」と「都道府県」の条件を満たす投稿のid
     # @posts_post_type_keyword_prefecture_ids = @posts_post_type_keyword_prefecture.pluck(:id)

--- a/app/controllers/user_profiles_controller.rb
+++ b/app/controllers/user_profiles_controller.rb
@@ -2,86 +2,83 @@ class UserProfilesController < ApplicationController
   before_action :authenticate_user!, except:[:index, :show]
   before_action :ensure_user, only:[:edit, :update]
   
-  def profile_type
-  end
-  
   def new
     @user_profile = UserProfile.new
-    # @category_about_region = CategoryAboutRegion.new
-    # @category_incubation = CategoryIncubation.new
-    # @category_immigration_support = CategoryImmigrationSupport.new
-    # @category_job = CategoryJob.new
-    # @category_skill = CategorySkill.new
-    # @category_interest = CategoryInterest.new
-    # @category_about_regions = CategoryAboutRegion.all
-    # @category_incubations = CategoryIncubation.all
-    # @category_immigration_supports = CategoryImmigrationSupport.all
-    # @category_jobs = CategoryJob.all
-    # @category_skills = CategorySkill.all
-    # @category_interests = CategoryInterest.all
-    # @check_flags_profile_category_about_region = []
-    # @check_flags_profile_category_incubation = []
-    # @check_flags_profile_category_immigration_support = []
-    # @check_flags_profile_category_job = []
-    # @check_flags_profile_category_skill = []
-    # @check_flags_profile_category_interest = []
-    # if current_user.user_profile.present?
-    #   redirect_to ({controller: 'accounts', action: 'show', id: current_user.id}), notice: "プロフィールは登録済みです"
-    # end  
+    @category_about_region = CategoryAboutRegion.new
+    @category_incubation = CategoryIncubation.new
+    @category_immigration_support = CategoryImmigrationSupport.new
+    @category_job = CategoryJob.new
+    @category_skill = CategorySkill.new
+    @category_interest = CategoryInterest.new
+    @category_about_regions = CategoryAboutRegion.all
+    @category_incubations = CategoryIncubation.all
+    @category_immigration_supports = CategoryImmigrationSupport.all
+    @category_jobs = CategoryJob.all
+    @category_skills = CategorySkill.all
+    @category_interests = CategoryInterest.all
+    @check_flags_profile_category_about_region = []
+    @check_flags_profile_category_incubation = []
+    @check_flags_profile_category_immigration_support = []
+    @check_flags_profile_category_job = []
+    @check_flags_profile_category_skill = []
+    @check_flags_profile_category_interest = []
+    if current_user.user_profile.present?
+      redirect_to ({controller: 'accounts', action: 'show', id: current_user.id}), notice: "プロフィールは登録済みです"
+    end  
   end
   
   def create
     @user_profile = UserProfile.new(user_profile_params)
-    # category_about_region_ids = params[:category_about_region_id]
-    # category_incubation_ids = params[:category_incubation_id]
-    # category_immigration_support_ids = params[:category_immigration_support_id]
-    # category_job_ids = params[:category_job_id]
-    # category_skill_ids = params[:category_skill_id]
-    # category_interest_ids = params[:category_interest_id]
+    category_about_region_ids = params[:category_about_region_id]
+    category_incubation_ids = params[:category_incubation_id]
+    category_immigration_support_ids = params[:category_immigration_support_id]
+    category_job_ids = params[:category_job_id]
+    category_skill_ids = params[:category_skill_id]
+    category_interest_ids = params[:category_interest_id]
   
     if @user_profile.save
      
-      # if category_about_region_ids.present?
-      #   category_about_region_ids.each do |category_about_region_id|
-      #   profile_category_about_region = @user_profile.profile_category_about_regions.build(category_about_region_id: category_about_region_id)
-      #   profile_category_about_region.save
-      #   end
-      # end  
+       if category_about_region_ids.present?
+        category_about_region_ids.each do |category_about_region_id|
+         profile_category_about_region = @user_profile.profile_category_about_regions.build(category_about_region_id: category_about_region_id)
+         profile_category_about_region.save
+        end
+       end  
        
-      # if category_incubation_ids.present?
-      #   category_incubation_ids.each do |category_incubation_id|
-      #   profile_category_incubation = @user_profile.profile_category_incubations.build(category_incubation_id: category_incubation_id)
-      #   profile_category_incubation.save
-      #   end
-      # end  
+      if category_incubation_ids.present?
+        category_incubation_ids.each do |category_incubation_id|
+         profile_category_incubation = @user_profile.profile_category_incubations.build(category_incubation_id: category_incubation_id)
+         profile_category_incubation.save
+        end
+      end  
       
-      # if category_immigration_support_ids.present?
-      #   category_immigration_support_ids.each do |category_immigration_support_id|
-      #   profile_category_immigration_support = @user_profile.profile_category_immigration_supports.build(category_immigration_support_id: category_immigration_support_id)
-      #   profile_category_immigration_support.save
-      #   end
-      # end  
+      if category_immigration_support_ids.present?
+        category_immigration_support_ids.each do |category_immigration_support_id|
+         profile_category_immigration_support = @user_profile.profile_category_immigration_supports.build(category_immigration_support_id: category_immigration_support_id)
+         profile_category_immigration_support.save
+        end
+      end  
       
-      # if category_job_ids.present?
-      #   category_job_ids.each do |category_job_id|
-      #     profile_category_job = @user_profile.profile_category_jobs.build(category_job_id: category_job_id)
-      #     profile_category_job.save
-      #   end 
-      # end  
+      if category_job_ids.present?
+        category_job_ids.each do |category_job_id|
+          profile_category_job = @user_profile.profile_category_jobs.build(category_job_id: category_job_id)
+          profile_category_job.save
+        end 
+      end  
       
-      # if category_skill_ids.present?
-      #   category_skill_ids.each do |category_skill_id|
-      #     profile_category_skill = @user_profile.profile_category_skills.build(category_skill_id: category_skill_id)
-      #     profile_category_skill.save
-      #   end
-      # end
+      if category_skill_ids.present?
+        category_skill_ids.each do |category_skill_id|
+          profile_category_skill = @user_profile.profile_category_skills.build(category_skill_id: category_skill_id)
+          profile_category_skill.save
+        end
+      end
       
-      # if category_interest_ids.present?
-      #   category_interest_ids.each do |category_interest_id|
-      #     profile_category_interest = @user_profile.profile_category_interests.build(category_interest_id: category_interest_id)
-      #     profile_category_interest.save
-      #   end
-      # end 
+      if category_interest_ids.present?
+        category_interest_ids.each do |category_interest_id|
+          profile_category_interest = @user_profile.profile_category_interests.build(category_interest_id: category_interest_id)
+          profile_category_interest.save
+        end
+      end 
       
        redirect_to @user_profile, notice:"登録が完了しました"
     else
@@ -90,89 +87,88 @@ class UserProfilesController < ApplicationController
     
   end
   
-  # def edit
-  #   @user_profile = UserProfile.find(params[:id])
-  #   @profile_region_flag = true
-  #   @category_about_regions = CategoryAboutRegion.all
-  #   @category_incubations = CategoryIncubation.all
-  #   @category_immigration_supports = CategoryImmigrationSupport.all
-  #   @category_jobs = CategoryJob.all
-  #   @category_skills = CategorySkill.all
-  #   @category_interests = CategoryInterest.all
-  #   if @user_profile.profile_type1 == true
-  #   @profile_region_flag = true
-  #   end
-  #   if @user_profile.profile_type2 == true
-  #   @profile_business_flag = true
-  #   end
-  #   if @user_profile.public_status_region == 1
-  #   @public_status_region_flag = true
-  #   end
-  #   if @user_profile.public_status_business == 1
-  #   @public_status_business_flag = true
-  #   end
+  def edit
+    @user_profile = UserProfile.find(params[:id])
+    @category_about_regions = CategoryAboutRegion.all
+    @category_incubations = CategoryIncubation.all
+    @category_immigration_supports = CategoryImmigrationSupport.all
+    @category_jobs = CategoryJob.all
+    @category_skills = CategorySkill.all
+    @category_interests = CategoryInterest.all
+    if @user_profile.profile_type1 == true
+     @profile_region_flag = true
+    end
+    if @user_profile.profile_type2 == true
+     @profile_business_flag = true
+    end
+    if @user_profile.public_status_region == 1
+     @public_status_region_flag = true
+    end
+    if @user_profile.public_status_business == 1
+     @public_status_business_flag = true
+    end
     
     
-  #   @check_flags_profile_category_about_region = []
-  #   @category_about_regions.each_with_index do |category_about_region, index|
-  #     pca = ProfileCategoryAboutRegion.where(category_about_region_id: category_about_region.id).where(user_profile_id: @user_profile.id)
-  #     if pca.empty?
-  #       @check_flags_profile_category_about_region[index] = false
-  #     else
-  #       @check_flags_profile_category_about_region[index] = true
-  #     end
-  #   end
+    @check_flags_profile_category_about_region = []
+    @category_about_regions.each_with_index do |category_about_region, index|
+      pca = ProfileCategoryAboutRegion.where(category_about_region_id: category_about_region.id).where(user_profile_id: @user_profile.id)
+      if pca.empty?
+        @check_flags_profile_category_about_region[index] = false
+      else
+        @check_flags_profile_category_about_region[index] = true
+      end
+    end
     
-  #   @check_flags_profile_category_incubation = []
-  #   @category_incubations.each_with_index do |category_incubation, index|
-  #     pci = ProfileCategoryIncubation.where(category_incubation_id: category_incubation.id).where(user_profile_id: @user_profile.id)
-  #     if pci.empty?
-  #       @check_flags_profile_category_incubation[index] = false
-  #     else
-  #       @check_flags_profile_category_incubation[index] = true
-  #     end
-  #   end
+    @check_flags_profile_category_incubation = []
+    @category_incubations.each_with_index do |category_incubation, index|
+      pci = ProfileCategoryIncubation.where(category_incubation_id: category_incubation.id).where(user_profile_id: @user_profile.id)
+      if pci.empty?
+        @check_flags_profile_category_incubation[index] = false
+      else
+        @check_flags_profile_category_incubation[index] = true
+      end
+    end
     
-  #   @check_flags_profile_category_immigration_support = []
-  #   @category_immigration_supports.each_with_index do |category_immigration_support, index|
-  #     pcis = ProfileCategoryImmigrationSupport.where(category_immigration_support_id: category_immigration_support.id).where(user_profile_id: @user_profile.id)
-  #     if pcis.empty?
-  #       @check_flags_profile_category_immigration_support[index] = false
-  #     else
-  #       @check_flags_profile_category_immigration_support[index] = true
-  #     end
-  #   end
+    @check_flags_profile_category_immigration_support = []
+    @category_immigration_supports.each_with_index do |category_immigration_support, index|
+      pcis = ProfileCategoryImmigrationSupport.where(category_immigration_support_id: category_immigration_support.id).where(user_profile_id: @user_profile.id)
+      if pcis.empty?
+        @check_flags_profile_category_immigration_support[index] = false
+      else
+        @check_flags_profile_category_immigration_support[index] = true
+      end
+    end
     
-  #   @check_flags_profile_category_job = []
-  #   @category_jobs.each_with_index do |category_job, index|
-  #     pcj = ProfileCategoryJob.where(category_job_id: category_job.id).where(user_profile_id: @user_profile.id)
-  #     if pcj.empty?
-  #       @check_flags_profile_category_job[index] = false
-  #     else
-  #       @check_flags_profile_category_job[index] = true
-  #     end
-  #   end
+    @check_flags_profile_category_job = []
+    @category_jobs.each_with_index do |category_job, index|
+      pcj = ProfileCategoryJob.where(category_job_id: category_job.id).where(user_profile_id: @user_profile.id)
+      if pcj.empty?
+        @check_flags_profile_category_job[index] = false
+      else
+        @check_flags_profile_category_job[index] = true
+      end
+    end
     
-  #   @check_flags_profile_category_skill = []
-  #   @category_skills.each_with_index do |category_skill, index|
-  #     pcs = ProfileCategorySkill.where(category_skill_id: category_skill.id).where(user_profile_id: @user_profile.id)
-  #     if pcs.empty?
-  #       @check_flags_profile_category_skill[index] = false
-  #     else
-  #       @check_flags_profile_category_skill[index] = true
-  #     end
-  #   end
+    @check_flags_profile_category_skill = []
+    @category_skills.each_with_index do |category_skill, index|
+      pcs = ProfileCategorySkill.where(category_skill_id: category_skill.id).where(user_profile_id: @user_profile.id)
+      if pcs.empty?
+        @check_flags_profile_category_skill[index] = false
+      else
+        @check_flags_profile_category_skill[index] = true
+      end
+    end
     
-  #   @check_flags_profile_category_interest = []
-  #   @category_interests.each_with_index do |category_interest, index|
-  #     pcin = ProfileCategoryInterest.where(category_interest_id: category_interest.id).where(user_profile_id: @user_profile.id)
-  #     if pcin.empty?
-  #       @check_flags_profile_category_interest[index] = false
-  #     else
-  #       @check_flags_profile_category_interest[index] = true
-  #     end
-  #   end 
-  # end
+    @check_flags_profile_category_interest = []
+    @category_interests.each_with_index do |category_interest, index|
+      pcin = ProfileCategoryInterest.where(category_interest_id: category_interest.id).where(user_profile_id: @user_profile.id)
+      if pcin.empty?
+        @check_flags_profile_category_interest[index] = false
+      else
+        @check_flags_profile_category_interest[index] = true
+      end
+    end 
+  end
   
   def update
     @user_profile = UserProfile.find(params[:id])

--- a/app/models/user_profile.rb
+++ b/app/models/user_profile.rb
@@ -15,6 +15,5 @@ class UserProfile < ApplicationRecord
   
   validates :screen_name, presence: true
   #validates :prefecture, presence: true
-  # validates :public_status_id, presence: true
   
 end

--- a/app/views/layouts/_user_profile_business.html.erb
+++ b/app/views/layouts/_user_profile_business.html.erb
@@ -51,7 +51,8 @@
      <% if user_profile.public_status_business == 1 %>
       <div class="public-status">公開中</div>
      <% elsif user_profile.public_status_business == 2 %>
-      <div class="public-status">非公開</div>
+      <div class="public-status">非公開<br>
+      <small style="font-size: small; font-weight: normal; color: grey;">※プロフィールが非公開だと投稿は公開されません。<br>※プロフィールが非公開でもコメントやメッセージを送信すると、名前やプロフィール写真は公開されます。</small></div>  
      <% end %>
     <% end %> 
     <% if user_signed_in? && user_profile.user_id == current_user.id %> 

--- a/app/views/layouts/_user_profile_form.html.erb
+++ b/app/views/layouts/_user_profile_form.html.erb
@@ -1,27 +1,12 @@
 <div class="container">
   <div class="row">
     <div class="col-md-8 offset-md-2">
-      <h1 class="text-center text-black">プロフィール情報登録</h1>
         <%= bootstrap_form_with(model: user_profile, local: true) do |f| %>
         　<div>
         　  <%= f.hidden_field :user_id, :value => current_user.id %>
-            <%#= f.text_field :screen_name, label:"表示名", required: true  %>
-            <%#= f.file_field :avatar, label:"プロフィール画像" %> 
-            <%# prefecture = ['北海道','青森県','岩手県','宮城県','秋田県','山形県','福島県','茨城県','栃木県','群馬県','埼玉県','千葉県','東京都','神奈川県','新潟県','富山県','石川県','福井県','山梨県','長野県','岐阜県','静岡県','愛知県','三重県','滋賀県','京都府','大阪府','兵庫県','奈良県','和歌山県','鳥取県','島根県','岡山県','広島県','山口県','徳島県','香川県','愛媛県','高知県','福岡県','佐賀県','長崎県','熊本県','大分県','宮崎県','鹿児島県','沖縄県'] %>
-            <%# array = [["都道府県",""]] %>
-            <%# prefecture.each do |i| %>
-              <%# array << {i: i} %>
-            <%# end %>
-            
-            <%#= f.select :prefecture, {'北海道': '北海道', '青森県': '青森県', '岩手県': '岩手県', '宮城県': '宮城県', '秋田県': '秋田県', '山形県': '山形県', '福島県': '福島県', '茨城県': '茨城県', '栃木県': '栃木県', '群馬県': '群馬県', '埼玉県': '埼玉県', '千葉県': '千葉県', '東京都': '東京都', '神奈川県': '神奈川県', '新潟県': '新潟県', '富山県': '富山県', '石川県': '石川県', '福井県': '福井県', '山梨県': '山梨県', '長野県': '長野県', '岐阜県': '岐阜県', '静岡県': '静岡県', '愛知県': '愛知県', '三重県': '三重県', '滋賀県': '滋賀県', '京都府': '京都府', '大阪府': '大阪府', '兵庫県': '兵庫県', '奈良県': '奈良県', '和歌山県': '和歌山県', '鳥取県': '鳥取県', '島根県': '島根県', '岡山県': '岡山県', '広島県': '広島県', '山口県': '山口県', '徳島県': '徳島県', '香川県': '香川県', '愛媛県': '愛媛県', '高知県': '高知県', '福岡県': '福岡県', '佐賀県': '佐賀県', '長崎県': '長崎県', '熊本県': '熊本県', '大分県': '大分県', '宮崎県': '宮崎県', '鹿児島県': '鹿児島県', '沖縄県': '沖縄県'}, { include_blank: '選択してください', label: '都道府県'}, { class: 'form-control' , required: true }  %>
-            <%#= f.text_field :city, label:"市町村以下" %>
-            <!--<p>どちらで登録するかお選びください</p>-->
             <div>
-              <%#= f.check_box :profile_type1, label: "地域側" %>
-              <!--<input name="user_profile[profile_type1]" type="hidden" value="0" autocomplete="off" />-->
-              <!--<input class="form-check-input" type="checkbox" value="1" name="user_profile[profile_type1]" id="user_profile_profile_type1" <%= @profile_region_flag ? checked="checked" : "" %> /><label class="form-check-label" for="user_profile_profile_type1">地域側</label>-->
-              <!--<div class="user_profile_profile_type1">地域側として登録する内容です。-->
               <% if profile_region_flag %>
+                <h1 class="text-center text-black">地域情報情報登録</h1>
                 <%= f.hidden_field :profile_type1, value: "1" %>
                 <%= f.text_area :about_region, label:"地域について", size: "40x15", placeholder:"" %>
                 <div class="category">地域について<br>
@@ -46,25 +31,17 @@
                 </div>
                 <%= f.text_area :other1, label:"その他", size: "40x15", placeholder:"" %>
                 <div class="public_status">
-                  <!--<div class="form-check mb-3 form-switch">-->
-                  <!--<input autocomplete="off" name="public_status_id" type="hidden" value="1">-->
-                  <!--<input class="form-check-input" id="public_status_id" name="public_status_id" type="checkbox" value="1">-->
-                  <!--<label class="form-check-label" for="public_status_id">公開</label>-->
                   <div class="form-check form-check-inline"><input class="form-check-input" type="radio" value="1" name="user_profile[public_status_region]" id="public_status_region_1" <%= public_status_region_flag ? checked="checked" : "" %> /><label class="form-check-label" for="public_status_region_1">公開</label></div>
                   <div class="form-check form-check-inline"><input class="form-check-input" type="radio" value="2" name="user_profile[public_status_region]" id="public_status_region_2" <%= public_status_region_flag ? "" : checked="checked"%> /><label class="form-check-label" for="public_status_region_2">非公開</label></div>
                 </div>
-                <!--</div>-->
               <% end %>  
               </div>
               
             </div>
             
             <div>
-            <%#= f.check_box :profile_type2, label: "起業希望者" %>
-            <!--<input name="user_profile[profile_type2]" type="hidden" value="0" autocomplete="off" />-->
-            <!--<input class="form-check-input" type="checkbox" value="1" name="user_profile[profile_type2]" id="user_profile_profile_type2" <%#= @profile_business_flag ? checked="checked" : "" %>/><label class="form-check-label" for="user_profile_profile_type2">起業希望者</label>-->
-              <!--<div class="user_profile_profile_type2">起業希望者として登録する内容です。-->
                <% if profile_business_flag %>
+                <h1 class="text-center text-black">プロフィール情報登録</h1>
                 <%= f.hidden_field :profile_type2, value: 1 %>
                 <%= f.text_area :job, label:"職業", size: "40x15", placeholder:"" %>
                 <div class="category">職業<br>

--- a/app/views/layouts/_user_profile_region.html.erb
+++ b/app/views/layouts/_user_profile_region.html.erb
@@ -38,7 +38,8 @@
      <% if user_profile.public_status_region == 1 %>
       <div class="public-status">公開中</div>
      <% elsif user_profile.public_status_region == 2 %>
-      <div class="public-status">非公開</div>
+      <div class="public-status">非公開<br>
+      <small style="font-size: small; font-weight: normal; color: grey;">※プロフィールが非公開だと投稿は公開されません。<br>※プロフィールが非公開でもコメントやメッセージを送信すると、名前やプロフィール写真は公開されます。</small></div>
      <% end %>
     <% end %> 
     <%# end %>

--- a/app/views/names/_form.html.erb
+++ b/app/views/names/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-md-8 offset-md-2">
       <h1 class="text-center text-black">プロフィール情報登録</h1>
-        <%= bootstrap_form_with(model: user_profile, url: name_path) do |f| %>
+        <%= bootstrap_form_with(model: user_profile, url: names_path) do |f| %>
         　<div>
         　  <%= f.hidden_field :user_id, :value => current_user.id %>
             <%= f.text_field :screen_name, label:"表示名", required: true  %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -24,7 +24,7 @@
    </div>
   </div>
   
-  <P><%= @posts.count %>件の投稿</P>
+  <P><%= @posts_count %>件の投稿</P>
   <div class="row">
     <% @posts.each do |post| %>
      <% if post.public_status_id == 1 %>

--- a/app/views/posts_business/index.html.erb
+++ b/app/views/posts_business/index.html.erb
@@ -14,52 +14,49 @@
      <div>投稿のタグ</div>
      <div class="category"><span class="badge text-bg-primary">やりたいこと</span><br>
       <% @category_wants.each_with_index do |category_want, index| %>
-        <nobr><input class="form-check-input" type="checkbox" name="category_want_id[]" value="<%= category_want.id%>" <%= @check_flags_category_wants[index] ? 'checked' : '' %> >
-        <%= category_want.tag_name %></nobr>&emsp;
+        <input class="form-check-input" type="checkbox" name="category_want_id[]" value="<%= category_want.id%>" <%= @check_flags_category_wants[index] ? 'checked' : '' %> >
+        <%= category_want.tag_name %>&emsp;
       <% end %>
      </div>
      <div class="category"><span class="badge text-bg-secondary">本気度</span><br>
        <% @category_earnests.each_with_index do |category_earnest, index| %>
-        <nobr><input class="form-check-input" type="checkbox" name="category_earnest_id[]" value="<%= category_earnest.id %>" <%= @check_flags_category_earnests[index] ? 'checked' : '' %> >
-        <%= category_earnest.tag_name %></nobr>&emsp;
+        <input class="form-check-input" type="checkbox" name="category_earnest_id[]" value="<%= category_earnest.id %>" <%= @check_flags_category_earnests[index] ? 'checked' : '' %> >
+        <%= category_earnest.tag_name %>&emsp;
        <% end %>
      </div>
      <div>プロフィールのタグ</div> 
      <div class="category"><span class="badge rounded-pill text-bg-primary">職業</span><br>
       <% @category_jobs.each_with_index do |category_job, index| %>
-       <nobr><input class="form-check-input", type="checkbox", name="category_job_id[]", value="<%= category_job.id %>" <%= @check_flags_category_jobs[index] ? 'checked' : '' %>>
-       <%= category_job.tag_name %></nobr>&emsp;
+       <input class="form-check-input", type="checkbox", name="category_job_id[]", value="<%= category_job.id %>" <%= @check_flags_category_jobs[index] ? 'checked' : '' %>>
+       <%= category_job.tag_name %>&emsp;
       <% end %>
      </div> 
      <div class="category"><span class="badge rounded-pill text-bg-secondary">得意なこと</span><br>
       <% @category_skills.each_with_index do |category_skill, index| %>
-        <nobr><input class="form-check-input" type="checkbox" name="category_skill_id[]" value="<%= category_skill.id %>" <%= @check_flags_category_skills[index] ? 'checked' : '' %>>
-        <%= category_skill.tag_name %></nobr>&emsp;
+        <input class="form-check-input" type="checkbox" name="category_skill_id[]" value="<%= category_skill.id %>" <%= @check_flags_category_skills[index] ? 'checked' : '' %>>
+        <%= category_skill.tag_name %>&emsp;
       <% end %>
      </div> 
      <div class="category"><span class="badge rounded-pill text-bg-warning">興味のあること</span><br>
       <% @category_interests.each_with_index do |category_interest, index| %>
-       <nobr><input class="form-check-input", type="checkbox", name="category_interest_id[]", value="<%= category_interest.id %>" <%= @check_flags_category_interests[index] ? 'checked' : '' %>>
-       <%= category_interest.tag_name %></nobr>&emsp;
+       <input class="form-check-input", type="checkbox", name="category_interest_id[]", value="<%= category_interest.id %>" <%= @check_flags_category_interests[index] ? 'checked' : '' %>>
+       <%= category_interest.tag_name %>&emsp;
       <% end %>
      </div> 
       <h6>検索方法</6>
       <div><input class="form-check-input", type="radio", name="search_type", value="1" <%= @search_type != "2" ? "checked" : "" %> >OR検索（選択したタグを含む投稿をすべて表示）</div>
       <div><input class="form-check-input", type="radio", name="search_type", value="2" <%= @search_type == "2" ? "checked" : "" %>>AND検索（選択したタグをすべて含む投稿を表示）</div>
-     </div>
-     <div><input class="btn btn-secondary" type="submit" value="検索" style="margin-bottom: 20px;"></div>
+      <div><input class="btn btn-secondary" type="submit" value="検索" style="margin-top: 20px; margin-bottom: 20px;"></div>
     </form>
     <div><a class="btn btn-secondary" href="/posts_business" role="button" style="margin-bottom: 40px;">検索条件をクリア</a></div>
-   </div>
   
-  <P><%= @posts_count %>件の投稿</P>
-  <div class="row">
-    <% @posts.each do |post| %>
-     <% if post.public_status_id == 1  || post.public_status_id == 3 %>
-      <%= render "layouts/post_card", post: post %>
-     <% end %>
+   <P><%= @posts_count %>件の投稿</P>
+   <% @posts.each do |post| %>
+    <% if post.public_status_id == 1  || post.public_status_id == 3 %>
+     <%= render "layouts/post_card", post: post %>
     <% end %>
+   <% end %>
+   <div style="margin-top: 20px;"><%= paginate @posts, theme: 'twitter-bootstrap-4' %></div>
+  </div>
  </div>
- <div style="margin-top: 20px;"><%= paginate @posts, theme: 'twitter-bootstrap-4' %></div>
-</div>
 </div>

--- a/app/views/posts_region/index.html.erb
+++ b/app/views/posts_region/index.html.erb
@@ -14,71 +14,68 @@
      <div>投稿のタグ</div>
      <div class="category"><span class="badge text-bg-primary">地域資源</span><br>
       <% @category_resources.each_with_index do |category_resource, index| %>
-        <nobr><input class="form-check-input" type="checkbox" name="category_resource_id[]" value="<%= category_resource.id%>" <%= @check_flags_category_resources[index] ? 'checked' : '' %> >
-        <%= category_resource.tag_name %></nobr>&emsp;
+        <input class="form-check-input category-label" type="checkbox" name="category_resource_id[]" value="<%= category_resource.id%>" <%= @check_flags_category_resources[index] ? 'checked' : '' %> >
+        <%= category_resource.tag_name %>&emsp;
       <% end %>
      </div>
      <div class="category"><span class="badge text-bg-secondary">地域課題 </span><br>
        <% @category_issues.each_with_index do |category_issue, index| %>
-        <nobr><input class="form-check-input" type="checkbox" name="category_issue_id[]" value="<%= category_issue.id %>" <%= @check_flags_category_issues[index] ? 'checked' : '' %> >
-        <%= category_issue.tag_name %></nobr>&emsp;
+        <input class="form-check-input" type="checkbox" name="category_issue_id[]" value="<%= category_issue.id %>" <%= @check_flags_category_issues[index] ? 'checked' : '' %> >
+        <%= category_issue.tag_name %>&emsp;
        <% end %>
      </div> 
      <div class="category"><span class="badge text-bg-warning">需要</span><br>
       <% @category_markets.each_with_index do |category_market, index| %>
-        <nobr><input class="form-check-input" type="checkbox" name="category_market_id[]" value="<%= category_market.id %>" <%= @check_flags_category_markets[index] ? 'checked' : '' %>>
-        <%= category_market.tag_name %></nobr>&emsp;
+        <input class="form-check-input" type="checkbox" name="category_market_id[]" value="<%= category_market.id %>" <%= @check_flags_category_markets[index] ? 'checked' : '' %>>
+        <%= category_market.tag_name %>&emsp;
       <% end %>
      </div>
      <div class="category"><span class="badge text-bg-info">地域の特色</span><br>
       <% @category_features.each_with_index do |category_feature, index| %>
-       <nobr><input class="form-check-input", type="checkbox", name="category_feature_id[]", value="<%= category_feature.id %>" <%= @check_flags_category_features[index] ? 'checked' : '' %>>
-       <%= category_feature.tag_name %></nobr>&emsp;
+       <input class="form-check-input", type="checkbox", name="category_feature_id[]", value="<%= category_feature.id %>" <%= @check_flags_category_features[index] ? 'checked' : '' %>>
+       <%= category_feature.tag_name %>&emsp;
       <% end %>
      </div> 
      <div class="category"><span class="badge text-bg-dark">実現可能性</span><br>
       <% @category_realizabilities.each_with_index do |category_realizability, index| %>
-       <nobr><input class="form-check-input", type="checkbox", name="category_realizability_id[]", value="<%= category_realizability.id %>" <%= @check_flags_category_realizabilities[index] ? 'checked' : '' %>>
-       <%= category_realizability.tag_name %></nobr>&emsp;
+       <input class="form-check-input", type="checkbox", name="category_realizability_id[]", value="<%= category_realizability.id %>" <%= @check_flags_category_realizabilities[index] ? 'checked' : '' %>>
+       <%= category_realizability.tag_name %>&emsp;
       <% end %>
      </div>
      <div>プロフィールのタグ</div>
      <div class="category"><span class="badge rounded-pill text-bg-primary">地域について</span><br>
       <% @category_about_regions.each_with_index do |category_about_region, index| %>
-       <nobr><input class="form-check-input", type="checkbox", name="category_about_region_id[]", value="<%= category_about_region.id %>" <%= @check_flags_category_about_regions[index] ? 'checked' : '' %>>
-       <%= category_about_region.tag_name %></nobr>&emsp;
+       <input class="form-check-input", type="checkbox", name="category_about_region_id[]", value="<%= category_about_region.id %>" <%= @check_flags_category_about_regions[index] ? 'checked' : '' %>>
+       <%= category_about_region.tag_name %>&emsp;
       <% end %>
      </div> 
      <div class="category"><span class="badge rounded-pill text-bg-secondary">地域の起業支援</span><br>
       <% @category_incubations.each_with_index do |category_incubation, index| %>
-        <nobr><input class="form-check-input" type="checkbox" name="category_incubation_id[]" value="<%= category_incubation.id %>" <%= @check_flags_category_incubations[index] ? 'checked' : '' %>>
-        <%= category_incubation.tag_name %></nobr>&emsp;
+        <input class="form-check-input" type="checkbox" name="category_incubation_id[]" value="<%= category_incubation.id %>" <%= @check_flags_category_incubations[index] ? 'checked' : '' %>>
+        <%= category_incubation.tag_name %>&emsp;
       <% end %>
      </div> 
      <div class="category"><span class="badge rounded-pill text-bg-warning">地域の移住支援</span><br>
       <% @category_immigration_supports.each_with_index do |category_immigration_support, index| %>
-       <nobr><input class="form-check-input", type="checkbox", name="category_immigration_support_id[]", value="<%= category_immigration_support.id %>" <%= @check_flags_category_immigration_supports[index] ? 'checked' : '' %>>
-       <%= category_immigration_support.tag_name %></nobr>&emsp;
+       <input class="form-check-input", type="checkbox", name="category_immigration_support_id[]", value="<%= category_immigration_support.id %>" <%= @check_flags_category_immigration_supports[index] ? 'checked' : '' %>>
+       <%= category_immigration_support.tag_name %>&emsp;
       <% end %>
      </div> 
-      <h6>検索方法</6>
-      <div><input class="form-check-input", type="radio", name="search_type", value="1" <%= @search_type != "2" ? "checked" : "" %> >OR検索（選択したタグを含む投稿をすべて表示）</div>
-      <div><input class="form-check-input", type="radio", name="search_type", value="2" <%= @search_type == "2" ? "checked" : "" %>>AND検索（選択したタグをすべて含む投稿を表示）</div>
-     </div>
-     <div><input class="btn btn-secondary" type="submit" value="検索" style="margin-bottom: 20px;"></div>
+     <h6>検索方法</6>
+     <div><input class="form-check-input", type="radio", name="search_type", value="1" <%= @search_type != "2" ? "checked" : "" %> >OR検索（選択したタグを含む投稿をすべて表示）</div>
+     <div><input class="form-check-input", type="radio", name="search_type", value="2" <%= @search_type == "2" ? "checked" : "" %>>AND検索（選択したタグをすべて含む投稿を表示）</div>
+     <div><input class="btn btn-secondary" type="submit" value="検索" style="margin-top: 20px; margin-bottom: 20px;"></div>
     </form>
     <div><a class="btn btn-secondary" href="/posts_region" role="button" style="margin-bottom: 40px;">検索条件をクリア</a></div>
-   </div>
   
   
-  <P><%= @posts.count %>件の投稿</P>
-  <div class="row">
-    <% @posts.each do |post| %>
-     <% if post.public_status_id == 1 || post.public_status_id == 3 %>
-      <%= render "layouts/post_card", post: post %>
-     <% end %>
+   <P><%= @posts_count %>件の投稿</P>
+   <% @posts.each do |post| %>
+    <% if post.public_status_id == 1 || post.public_status_id == 3 %>
+     <%= render "layouts/post_card", post: post %>
     <% end %>
+   <% end %>
+   <div style="margin-top: 20px;"><%= paginate @posts, theme: 'twitter-bootstrap-4' %></div>
+  </div>
  </div>
- <div style="margin-top: 20px;"><%= paginate @posts, theme: 'twitter-bootstrap-4' %></div>
-</div>
 </div>

--- a/app/views/user_profiles/profile_type.html.erb
+++ b/app/views/user_profiles/profile_type.html.erb
@@ -1,16 +1,7 @@
 <div class="container">
   <p>どちらで登録するか選択してください</p>
   <small>登録できるプロフィールは「地域側」「起業希望者」それぞれ一つずつです。</small>
-  <!--<%= bootstrap_form_with(url: new_user_profile_path) do |f| %>-->
-  <!-- <%= f.hidden_field :id, value: current_user.user_profile.id %> -->
-  <!-- <%= f.radio_button :profile_type1, true, label:"地域側", inline: true %>-->
-  <!-- <%= f.radio_button :profile_type2, true, label:"起業希望者", inline: true %>-->
-  <!-- <div class="submit"><%= f.submit %></div>-->
-   <!--<div class="submit"><%#= f.submit :"選択" %></div>-->
-  <!--<% end %>-->
-  <%#= link_to user_profiles_region_form_path do  %>
   <div>
-   <!--editに-->
   <%= link_to edit_user_profiles_region_path(current_user.user_profile) do  %>
    <button class="btn btn-success" type="submit">地域側</button>
   <% end %> 


### PR DESCRIPTION
 プロフィール未登録または非公開で投稿を作成しようとすると、プロフィールを登録して公開するようにメッセージが出る。
プロフィール非公開の人の投稿や非公開の投稿は表示されないように修正。

投稿検索で、条件を選択して検索した後、更に条件を指定して検索できなかった不具合を修正。